### PR TITLE
Use the new lambda name.

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,7 +22,7 @@ jobs:
   deploy:
     uses: nationalarchives/dr2-github-actions/.github/workflows/lambda_deploy.yml@main
     with:
-      lambda-name: ${{ github.event.inputs.environment }}-ip-lock-checker
+      lambda-name: ${{ github.event.inputs.environment }}-dr2-ip-lock-checker
       deployment-package: ip_lock_checker_lambda.zip
       environment: ${{ github.event.inputs.environment }}
       to-deploy: ${{ github.event.inputs.to-deploy }}


### PR DESCRIPTION
This hasn't been updated since we changed the names to include dr2.
